### PR TITLE
Fix spelling and update Codespaces references

### DIFF
--- a/docs/semana_5/tutorial_6.md
+++ b/docs/semana_5/tutorial_6.md
@@ -10,11 +10,11 @@ nav_order: 1
 ## Introducción
 {: .no_toc }
 
-Durante el transcurso de la semana comprendimos los retos para desmentalar el monolito y los posibles patrones y tácticas para dicho propósito. Uno de los puntos mencionados fue que las tácticas y métodos que involucran refactoring en el código pueden incurrir en riesgos y mantenimiento que como negocio estamos poco dispuestos a tolerar. Cuando comenzamos a aplicar los principios y prácticas de arquitecturas basadas en eventos, nos damos cuenta que podemos usar mecanismos no invasivos para poder distribuir los datos a través de los nuevos y existentes servicios. La identificación y publicación de esos conjuntos de datos a través de diferentes dominios (servicios) a sus correspondientes flujos de eventos es lo que llamamos [liberación de datos](https://learning.oreilly.com/library/view/building-event-driven-microservices/9781492057888/ch04.html#idm45380323922504){:target="_blank"}.
+Durante el transcurso de la semana comprendimos los retos para desmantelar el monolito y los posibles patrones y tácticas para dicho propósito. Uno de los puntos mencionados fue que las tácticas y métodos que involucran refactoring en el código pueden incurrir en riesgos y mantenimiento que como negocio estamos poco dispuestos a tolerar. Cuando comenzamos a aplicar los principios y prácticas de arquitecturas basadas en eventos, nos damos cuenta de que podemos usar mecanismos no invasivos para poder distribuir los datos a través de los nuevos y existentes servicios. La identificación y publicación de esos conjuntos de datos a través de diferentes dominios (servicios) a sus correspondientes flujos de eventos es lo que llamamos [liberación de datos](https://learning.oreilly.com/library/view/building-event-driven-microservices/9781492057888/ch04.html#idm45380323922504){:target="_blank"}.
 
-En este tutorial vamos implementar dos de los patrónes más populares para la liberación de datos: CDC y Outbox. Para ello, usaremos [Debezium](https://debezium.io/){:target="_blank"} como nuestra solución CDC y el [conector de Debezium para Apache Pulsar](https://archive.apache.org/dist/pulsar/pulsar-2.10.1/connectors/pulsar-io-debezium-mysql-2.10.1.nar){:target="_blank"} (sobra decir que seguiremos usando Apache Pulsar como nuestro broker de eventos).
+En este tutorial vamos implementar dos de los patrones más populares para la liberación de datos: CDC y Outbox. Para ello, usaremos [Debezium](https://debezium.io/){:target="_blank"} como nuestra solución CDC y el [conector de Debezium para Apache Pulsar](https://archive.apache.org/dist/pulsar/pulsar-2.10.1/connectors/pulsar-io-debezium-mysql-2.10.1.nar){:target="_blank"} (sobra decir que seguiremos usando Apache Pulsar como nuestro broker de eventos).
 
-Por último, vamos a usar [MySQL 8](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/){:target="_blank"} como nuestra base datos transaccional. Cabe aclarar que esta podría haber sido cualquier otro sistema manejador de bases de datos, tanto relacional como no relacional.
+Por último, vamos a usar [MySQL 8](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/){:target="_blank"} como nuestra base de datos transaccional. Cabe aclarar que esta podría haber sido cualquier otro sistema manejador de bases de datos, tanto relacional como no relacional.
 
 {: .note }
 > Antes de comenzar con el desarrollo, comience viendo el video tutorial donde se explican y elaboran algunos de los métodos a tratar aquí.
@@ -29,27 +29,27 @@ Por último, vamos a usar [MySQL 8](https://dev.mysql.com/doc/relnotes/mysql/8.0
 
 ## Preparación
 
-Haga un fork del template de [AeroAlpes](https://github.com/MISW4406/tutorial-6-cdc){:target="_blank"} en su repositorio de preferencia. Si necesita ayuda en como realizar este paso, use alguno de los siguientes links:
+Haga un fork del template de [AeroAlpes](https://github.com/MISW4406/tutorial-6-cdc){:target="_blank"} en su repositorio de preferencia. Si necesita ayuda en cómo realizar este paso, use alguno de los siguientes links:
 
 1. [Fork Github a Github](https://docs.github.com/en/get-started/quickstart/fork-a-repo){:target="_blank"}
 2. [Fork de Github a Gitlab](https://stackoverflow.com/questions/50973048/forking-git-repository-from-github-to-gitlab){:target="_blank"}
 3. [Fork de Github a Bitbucket](https://stackoverflow.com/questions/8137997/forking-from-github-to-bitbucket){:target="_blank"}
 
-Si esta usando Gitpod puede ejecutar su código de forma inmediata. De lo contrario, instale las dependencias en su máquina o ambiente de desarrollo, usando el archivo de `requirements.txt`. La versión de Python que se usa es 3.10 pero el requerimiento mínimo es de 3.7. Para crear ambiente de desarrollo virtuales en su máquina local, es sugerible usar [Conda](https://docs.conda.io/en/latest/){:target="_blank"}, en los recursos adicionales del sitio puede encontrar un [documento](/docs/recursos_adicionales/conda){:target="_blank"} sobre su configuración.
+Si está usando Codespaces puede ejecutar su código de forma inmediata. De lo contrario, instale las dependencias en su máquina o ambiente de desarrollo, usando el archivo de `requirements.txt`. La versión de Python que se usa es 3.10 pero el requerimiento mínimo es de 3.7. Para crear ambientes de desarrollo virtuales en su máquina local, es sugerible usar [Conda](https://docs.conda.io/en/latest/){:target="_blank"}, en los recursos adicionales del sitio puede encontrar un [documento](/docs/recursos_adicionales/conda){:target="_blank"} sobre su configuración.
 
-En el caso de Docker, es necesario que instale [Docker Desktop](https://www.docker.com/products/docker-desktop/){:target="_blank"} en su máquina de desarrollo y ejecute los comandos que puede encontrar en el archivo `.gitpod.yml`.
+En el caso de Docker, es necesario que instale [Docker Desktop](https://www.docker.com/products/docker-desktop/){:target="_blank"} en su máquina de desarrollo y ejecute los comandos que puede encontrar en el archivo de configuración del devcontainer.
 
-Para configurar Apache Pulsar debe configurar el cluster completo con los brokers, bookies y zookeepper. En ambientes locales lo mejor que puede hacer es usar el archivo [docker-compose.yml](https://github.com/MISW4406/tutorial-6-cdc/blob/main/docker-compose.yml){:target="_blank"} que encuentra en el repositorio. Así mismo, puede encontrar los archivos `.Dockerfile` para cada uno de los servicios que se deben desplegar. **Es importante tener en cuenta las configuraciones de red de los servicios**, si tiene muchos problemas entre ellos, deje que todos los servicios exponan en la interface 0.0.0.0 y todos se expongan en su localhost.
+Para configurar Apache Pulsar debe configurar el cluster completo con los brokers, bookies y zookeeper. En ambientes locales lo mejor que puede hacer es usar el archivo [docker-compose.yml](https://github.com/MISW4406/tutorial-6-cdc/blob/main/docker-compose.yml){:target="_blank"} que encuentra en el repositorio. Así mismo, puede encontrar los archivos `.Dockerfile` para cada uno de los servicios que se deben desplegar. **Es importante tener en cuenta las configuraciones de red de los servicios**, si tiene muchos problemas entre ellos, deje que todos los servicios exponan en la interface 0.0.0.0 y todos se expongan en su localhost.
 
-Para la configuración de Debezium puede usar el conector que ya se encuentra en el directorio `connectors/pulsar/` llamado `pulsar-io-debezium-mysql-2.10.1.nar` y el archivo de configuración `debezium-mysql-source-config.yaml`. Si desea descargar un versión distinta del conector puede usar el siguiente [link](https://pulsar.apache.org/download/){:target="_blank"}.
+Para la configuración de Debezium puede usar el conector que ya se encuentra en el directorio `connectors/pulsar/` llamado `pulsar-io-debezium-mysql-2.10.1.nar` y el archivo de configuración `debezium-mysql-source-config.yaml`. Si desea descargar una versión distinta del conector puede usar el siguiente [link](https://pulsar.apache.org/download/){:target="_blank"}.
 
-En el caso de la base de datos puede usar una de las imágenes oficiales de MySQL 8. Para ver su uso vea el archivo `docker-compose.yml`.
-
-{: .note }
-> Gitpod puede tardar un poco en instalar las dependencias la primera vez que crea el workspace. Usted puede observar el progreso de la instalación por medio de la vista de terminal en la parte inferior del IDE. Así mismo, en la esquina inferior derecha puede ver los pasos en ejecución con su correspondiente output.
+En el caso de la base de datos puede usar una de las imágenes oficiales de MySQL 8. Para ver su uso, consulte el archivo `docker-compose.yml`.
 
 {: .note }
-Dado que para ejecutar Debezium es necesario tener el Broker de eventos funcionando, y por ende la base datos, el orden para desplegar los componentes debe ser: Base de datos, Cluster Apache Pulsar y Conector de Debezium.
+> Codespaces puede tardar un poco en instalar las dependencias la primera vez que crea el workspace. Usted puede observar el progreso de la instalación por medio de la vista de terminal en la parte inferior del IDE. Así mismo, en la esquina inferior derecha puede ver los pasos en ejecución con su correspondiente output.
+
+{: .note }
+Dado que para ejecutar Debezium es necesario tener el broker de eventos funcionando, y por ende la base de datos, el orden para desplegar los componentes debe ser: Base de datos, clúster Apache Pulsar y Conector de Debezium.
 
 ## Manos a la obra
 
@@ -58,8 +58,8 @@ Comience por entender los cambios en la estructura del proyecto. Este ya contien
 Durante este tutorial, vamos a enfocarnos a:
 
 1. Entender el funcionamiento de CDC y Outbox.
-2. Entender como Debezium y en general las herramientas de CDC administran los cambios y procesan eventos de DDL
-3. Entender como las herramientas de CDC reaccionan ante fallos y privacidad de los datos.
+2. Entender cómo Debezium y en general las herramientas de CDC administran los cambios y procesan eventos de DDL.
+3. Entender cómo las herramientas de CDC reaccionan ante fallos y privacidad de los datos.
 
 ### 1. Despliegue los servicios
 
@@ -67,7 +67,7 @@ Tal como se mostró en el video tutorial, despliegue todos los servicios. En el 
 
 ### 2. Despliegue el conector Debezium
 
-En el README y video tutorial puede ver los comandos para ejectuar el conector de debezium usando el CLI Admin de Pulsar. También es buena idea desplegar el consumidor de eventos que el CLI Client de Pulsar nos provee para ver los cambios en tiempo real.
+En el README y video tutorial puede ver los comandos para ejecutar el conector de Debezium usando el CLI Admin de Pulsar. También es buena idea desplegar el consumidor de eventos que el CLI Client de Pulsar nos provee para ver los cambios en tiempo real.
 
 ### 3. Cree una nueva tabla
 
@@ -84,18 +84,18 @@ ALTER TABLE cupones
 ADD COLUMN valido_desde DATE AFTER vencimiento;
 ```
 
-Revise el cliente ¿Vio algún dato llegar? Nuevamente agreggue un nuevo registro ¿Vio cambios?
-Como tal vez ya lo habrá notado, en los tópicos específicos de cada tabla solo vemos llegar los cambios en los datos: nuevas filas, cambios en los mismas y la posible eliminación. Pero ¿qué pasa si quiero detectar cambios en los DDL? esto puede no sonar tan importante pero la verdad es que por medio de éste que podemos ser reactivos para cambiar esquemas en nuestras bases de datos sink. Piense por ejemplo en el caso ya mencionado y suponga que estos eventos que estamos capturando están siendo persistidos en nuestro Data Lake semi-estructurado o Vault. Puede que ya hayamos creado la tabla para persistir una copia exacta de nuestra tabla pero en formato append-only. Sin embargo, ahora un desarrollador en el backend realiza un cambio y no le avisa al equipo de datos (algo clásico). Probablemente nos encontremos en dos situaciones: 1. Insertamos sin el nuevo campo o 2. La inserción falla (dependiendo de como haya cambiado la tabla). 
+Revise el cliente ¿Vio algún dato llegar? Nuevamente agregue un nuevo registro ¿Vio cambios?
+Como tal vez ya lo habrá notado, en los tópicos específicos de cada tabla solo vemos llegar los cambios en los datos: nuevas filas, cambios en los mismos y la posible eliminación. Pero ¿qué pasa si quiero detectar cambios en los DDL? Esto puede no sonar tan importante, pero la verdad es que por medio de este mecanismo podemos ser reactivos para cambiar esquemas en nuestras bases de datos *sink*. Piense por ejemplo en el caso ya mencionado y suponga que estos eventos que estamos capturando están siendo persistidos en nuestro *Data Lake* semi estructurado o *Vault*. Puede que ya hayamos creado la tabla para persistir una copia exacta de nuestra tabla pero en formato append-only. Sin embargo, ahora un desarrollador en el *backend* realiza un cambio y no le avisa al equipo de datos (algo clásico). Probablemente nos encontremos en dos situaciones: 1. Insertamos sin el nuevo campo o 2. La inserción falla (dependiendo de cómo haya cambiado la tabla).
 
-Para evitar los anterior, Debezium también nos permite vigilar los cambios de DDL usando el tópico con el nombre del namespace o dataset. Por ende, si usted comienza a oir el tópico `reservas` y al mismo tiempo hace cambios en los esquemas de las tablas, podrá ver eventos llegar ¡Pruebelo! (este [link](https://debezium.io/documentation/reference/2.1/connectors/mysql.html#mysql-schema-change-topic){:target="_blank"} elabora un poco más sobre ello)
+Para evitar lo anterior, Debezium también nos permite vigilar los cambios de DDL usando el tópico con el nombre del *namespace* o *dataset*. Por ende, si usted comienza a oír el tópico `reservas` y al mismo tiempo hace cambios en los esquemas de las tablas, podrá ver eventos llegar ¡Pruébelo! (este [enlace](https://debezium.io/documentation/reference/2.1/connectors/mysql.html#mysql-schema-change-topic){:target="_blank"} elabora un poco más sobre ello)
 
 ### 4. Manejo de fallos
 
-Asuma ahora que hay fallos con la base de datos. Por ejemplo, pare ahora mismo la base de datos ¿Que vio? Vuelvala a subir y agregue registros ¿Sigue funcionando? Aunque CDC es una gran tecnología sigue siendo una herramienta más que nos puede dar dolores de cabeza. Piense como usted podría tolerar y manejar dichos fallos. El siguiente [artículo](https://levelup.gitconnected.com/fixing-debezium-connectors-when-they-break-on-production-49fb52d6ac4e) es una muy buena fuente para entender los posibles errores y cómo solucionarlos cuando usamos Debezium.
+Asuma ahora que hay fallos con la base de datos. Por ejemplo, pare ahora mismo la base de datos ¿Qué vio? Vuélvala a subir y agregue registros ¿Sigue funcionando? Aunque CDC es una gran tecnología, sigue siendo una herramienta más que nos puede dar dolores de cabeza. Piense cómo usted podría tolerar y manejar dichos fallos. El siguiente [artículo](https://levelup.gitconnected.com/fixing-debezium-connectors-when-they-break-on-production-49fb52d6ac4e) es una muy buena fuente para entender los posibles errores y cómo solucionarlos cuando usamos Debezium.
 
 {: .note }
 > Si se siente más "osado" en el directorio `/data` busque los archivos de bin logs y elimine uno.
 
 ### 5. Juegue con la herramienta
 
-Ya habiendo comprendido los features de Debezium y CDC, juegue un poco con la herramienta. Una buena forma es modificar el archivo de configuración y ver como cambia la ingestión de los datos. Para ello, use la [siguiente tabla](https://debezium.io/documentation/reference/2.1/connectors/mysql.html#_required_debezium_mysql_connector_configuration_properties){:target="_blank"}. Por ejemplo, ¿Cómo podríamos en este ejemplo evitar traer el código de los cupones? probablemente transmitir dicha información es riesgosa, pues alguién podría usar esos cupones para su propia beneficio. Revise en la documentación de Debezium como podemos limitar transferencia de tablas y columnas.
+Ya habiendo comprendido las características de Debezium y CDC, juegue un poco con la herramienta. Una buena forma es modificar el archivo de configuración y ver cómo cambia la ingestión de los datos. Para ello, use la [siguiente tabla](https://debezium.io/documentation/reference/2.1/connectors/mysql.html#_required_debezium_mysql_connector_configuration_properties){:target="_blank"}. Por ejemplo, ¿Cómo podríamos en este ejemplo evitar traer el código de los cupones? Probablemente transmitir dicha información sea riesgoso, pues alguien podría usar esos cupones para su propio beneficio. Revise en la documentación de Debezium cómo podemos limitar la transferencia de tablas y columnas.

--- a/docs/semana_5/tutorial_7.md
+++ b/docs/semana_5/tutorial_7.md
@@ -12,7 +12,7 @@ nav_order: 1
 
 En el anterior tutorial, pudimos ver un primer acercamiento a Event Sourcing en el momento en que creamos nuestra tabla de outbox siguiendo un modelo de append-only y persistimos los eventos de integración en una de las columnas de la misma. Al usar CDC podíamos usar estos datos si queríamos para poder hacer nuestras nuevas proyecciones. Sin embargo, tratar de hacer Event Sourcing usando una herramienta de liberación de datos puede involucrar múltiples puntos de fallo y posibles inconsistencias en la distribución de los eventos. Así mismo, de alguna manera estamos usando una base de datos que no fue diseñada para este propósito. 
 
-Por tal motivo, en este tutorial vamos a seguir enfoque más "canonico" de cuando Event Sourcing se trata. Veremos como usar un broker de eventos como nuestra event store y crear los componentes necesarios para oir y materilizar vistas usando CQRS + Event Sourcing.
+Por tal motivo, en este tutorial vamos a seguir un enfoque más "canónico" de cuando Event Sourcing se trata. Veremos cómo usar un broker de eventos como nuestra *event store* y crear los componentes necesarios para oír y materializar vistas usando CQRS + Event Sourcing.
 
 {: .note }
 > Antes de comenzar con el desarrollo, comience viendo el video tutorial donde se explican y elaboran algunos de los métodos a tratar aquí.
@@ -27,22 +27,22 @@ Por tal motivo, en este tutorial vamos a seguir enfoque más "canonico" de cuand
 
 ## Preparación
 
-Haga un fork del template de [AeroAlpes](https://github.com/MISW4406/tutorial-7-event-sourcing){:target="_blank"} en su repositorio de preferencia. Si necesita ayuda en como realizar este paso, use alguno de los siguientes links:
+Haga un fork del template de [AeroAlpes](https://github.com/MISW4406/tutorial-7-event-sourcing){:target="_blank"} en su repositorio de preferencia. Si necesita ayuda en cómo realizar este paso, use alguno de los siguientes links:
 
 1. [Fork Github a Github](https://docs.github.com/en/get-started/quickstart/fork-a-repo){:target="_blank"}
 2. [Fork de Github a Gitlab](https://stackoverflow.com/questions/50973048/forking-git-repository-from-github-to-gitlab){:target="_blank"}
 3. [Fork de Github a Bitbucket](https://stackoverflow.com/questions/8137997/forking-from-github-to-bitbucket){:target="_blank"}
 
-Si esta usando Gitpod puede ejecutar su código de forma inmediata. De lo contrario, instale las dependencias en su máquina o ambiente de desarrollo, usando el archivo de `requirements.txt`. La versión de Python que se usa es 3.10 pero el requerimiento mínimo es de 3.7. Para crear ambiente de desarrollo virtuales en su máquina local, es sugerible usar [Conda](https://docs.conda.io/en/latest/){:target="_blank"}, en los recursos adicionales del sitio puede encontrar un [documento](/docs/recursos_adicionales/conda){:target="_blank"} sobre su configuración.
+Si está usando Codespaces puede ejecutar su código de forma inmediata. De lo contrario, instale las dependencias en su máquina o ambiente de desarrollo, usando el archivo de `requirements.txt`. La versión de Python que se usa es 3.10 pero el requerimiento mínimo es de 3.7. Para crear ambientes de desarrollo virtuales en su máquina local, es sugerible usar [Conda](https://docs.conda.io/en/latest/){:target="_blank"}, en los recursos adicionales del sitio puede encontrar un [documento](/docs/recursos_adicionales/conda){:target="_blank"} sobre su configuración.
 
-En el caso de Docker, es necesario que instale [Docker Desktop](https://www.docker.com/products/docker-desktop/){:target="_blank"} en su máquina de desarrollo y ejecute los comandos que puede encontrar en el archivo `.gitpod.yml`.
+En el caso de Docker, es necesario que instale [Docker Desktop](https://www.docker.com/products/docker-desktop/){:target="_blank"} en su máquina de desarrollo y ejecute los comandos que puede encontrar en el archivo de configuración del devcontainer.
 
-Para configurar Apache Pulsar debe configurar el cluster completo con los brokers, bookies y zookeepper. En ambientes locales lo mejor que puede hacer es usar el archivo [docker-compose.yml](https://github.com/MISW4406/tutorial-7-event-sourcing/blob/main/docker-compose.yml){:target="_blank"} que encuentra en el repositorio. Así mismo, puede encontrar los archivos `.Dockerfile` para cada uno de los servicios que se deben desplegar. **Es importante tener en cuenta las configuraciones de red de los servicios**, si tiene muchos problemas entre ellos, deje que todos los servicios exponan en la interface 0.0.0.0 y todos se expongan en su localhost.
+Para configurar Apache Pulsar debe configurar el cluster completo con los brokers, bookies y zookeeper. En ambientes locales lo mejor que puede hacer es usar el archivo [docker-compose.yml](https://github.com/MISW4406/tutorial-7-event-sourcing/blob/main/docker-compose.yml){:target="_blank"} que encuentra en el repositorio. Así mismo, puede encontrar los archivos `.Dockerfile` para cada uno de los servicios que se deben desplegar. **Es importante tener en cuenta las configuraciones de red de los servicios**, si tiene muchos problemas entre ellos, deje que todos los servicios exponan en la interface 0.0.0.0 y todos se expongan en su localhost.
 
 En el caso de la base de datos puede usar una de las imágenes oficiales de MySQL 8. Para ver su uso vea el archivo `docker-compose.yml`.
 
 {: .note }
-> Gitpod puede tardar un poco en instalar las dependencias la primera vez que crea el workspace. Usted puede observar el progreso de la instalación por medio de la vista de terminal en la parte inferior del IDE. Así mismo, en la esquina inferior derecha puede ver los pasos en ejecución con su correspondiente output.
+> Codespaces puede tardar un poco en instalar las dependencias la primera vez que crea el workspace. Usted puede observar el progreso de la instalación por medio de la vista de terminal en la parte inferior del IDE. Así mismo, en la esquina inferior derecha puede ver los pasos en ejecución con su correspondiente output.
 
 ## Manos a la obra
 
@@ -55,27 +55,27 @@ Durante este tutorial, vamos a enfocarnos a:
 
 ### 1. Despliegue los servicios
 
-Tal como se mostró en el video tutorial, despliegue todos los servicios. En el README del proyecto puede encontrar como desplegar cada servicio de forma autónoma o vea nuevamente dichos pasos en el video tutorial. Recuerde que en nuestro caso puede usar los comandos de docker-compose por medio de `profiles`. 
+Tal como se mostró en el video tutorial, despliegue todos los servicios. En el README del proyecto puede encontrar cómo desplegar cada servicio de forma autónoma o vea nuevamente dichos pasos en el video tutorial. Recuerde que en nuestro caso puede usar los comandos de docker-compose por medio de `profiles`.
 
-### 2. Valide las políticas de retencion del Event Broker
+### 2. Valide las políticas de retención del Event Broker
 
-En el README y video tutorial puede ver los comandos validar y cambiar las políticas de retención de un conjunto de tópicos parte de un namespace. Ejecute los comandos de validación y en caso que la retención no sea -1, ejecute los comandos de cambio de políticas.
+En el README y video tutorial puede ver los comandos para validar y cambiar las políticas de retención de un conjunto de tópicos parte de un *namespace*. Ejecute los comandos de validación y, en caso de que la retención no sea -1, ejecute los comandos de cambio de políticas.
 
 ### 3. Extienda la recepción de eventos
 
-En el archivo **src/aeroalpes/modulos/vuelos/infraestructura/consumidores.py** modifique el método `suscribirse_a_eventos` para que no solo se entienda eventos de tipo `CrearReserva`, pero tambien `ReservaCancelada`. `ReservaPagada` y `ReservaAprobada`. No olvide seguir las notas en el TODO.
+En el archivo **src/aeroalpes/modulos/vuelos/infraestructura/consumidores.py** modifique el método `suscribirse_a_eventos` para que no solo se entiendan eventos de tipo `CrearReserva`, sino también `ReservaCancelada`, `ReservaPagada` y `ReservaAprobada`. No olvide seguir las notas en el TODO.
 
 ### 4. Extender proyección
 
-Extienda la proyección `ProyeccionReservasLista` que se encuentra en el archivo **src/aeroalpes/modulos/vuelos/infraestructura/proyecciones.py**. Piense como implementar el Merge de forma correcta reemplazando solo los campos que cambiaron. Opcionalmente trate de usar una Unidad de Trabajo para el manejo transaccional. Este es un buen ejemplo para el manejo de locks de lectura, dado que no queremos que una lectura sucia modifique nuestros datos de forma erronea.
+Extienda la proyección `ProyeccionReservasLista` que se encuentra en el archivo **src/aeroalpes/modulos/vuelos/infraestructura/proyecciones.py**. Piense cómo implementar el *merge* de forma correcta reemplazando solo los campos que cambiaron. Opcionalmente, trate de usar una Unidad de Trabajo para el manejo transaccional. Este es un buen ejemplo para el manejo de *locks* de lectura, dado que no queremos que una lectura sucia modifique nuestros datos de forma errónea.
 
 ### 5. Modificar consulta
 
-Modifique el archivo **src/aeroalpes/modulos/vuelos/aplicacion/queries/obtener_reserva.py** para que en vez de usar el repositorio use la vista definida en **src/aeroalpes/modulos/vuelos/infraestructura/vistas.py**. Modifique la vista para que devuelva objetos de dominio y no DTOs de infraestructura (no olvide validar si la consulta es correcta).
+Modifique el archivo **src/aeroalpes/modulos/vuelos/aplicacion/queries/obtener_reserva.py** para que, en vez de usar el repositorio, use la vista definida en **src/aeroalpes/modulos/vuelos/infraestructura/vistas.py**. Modifique la vista para que devuelva objetos de dominio y no DTOs de infraestructura (no olvide validar si la consulta es correcta).
 
 ### 6. Modifique API
 
-Modifique el endpoint `dar_reserva_usando_query` en **src/aeroalpes/api/vuelos.py** para que pueda filtar tambien `estado` y/o `id_cliente` (piense si es necesario crear un nuevo query o extender el actual). Una vez con ello ¡Despligue y pruebe!
+Modifique el endpoint `dar_reserva_usando_query` en **src/aeroalpes/api/vuelos.py** para que pueda filtrar también `estado` y/o `id_cliente` (piense si es necesario crear un nuevo query o extender el actual). Una vez con ello ¡Despliegue y pruebe!
 
 ### 7. Prueba final
 


### PR DESCRIPTION
## Summary
- fix spelling issues in Semana 5 tutorials
- replace Gitpod mentions with Codespaces
- note devcontainer configuration instead of `.gitpod.yml`

## Testing
- `bundle exec jekyll build` *(fails: bundler not installed)*
- `bundle install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68786855ba48832c978631407c841a51